### PR TITLE
[ZPLA-1062] Support schemes and tests for each target of a subproject in a workspace

### DIFF
--- a/src/com/facebook/buck/features/apple/project/NewNativeTargetProjectMutator.java
+++ b/src/com/facebook/buck/features/apple/project/NewNativeTargetProjectMutator.java
@@ -353,8 +353,15 @@ class NewNativeTargetProjectMutator {
                                             PBXGroup targetGroup, 
                                             ProjectFilesystem fileSystem) {
     String sourcesDir = "Sources";
+    String mainTargetName = targetGroup.getName();
+    if (productType == ProductTypes.UNIT_TEST
+      || productType == ProductTypes.UI_TEST) {
+      sourcesDir = "Tests";
+      mainTargetName = mainTargetName.replaceAll("Tests$", "");
+    }
+
     PBXGroup sourcesGroup = targetGroup.getOrCreateChildGroupByName(sourcesDir);
-    Path originalPath = Paths.get(this.originalPath.toString(), targetGroup.getName(), sourcesDir);
+    Path originalPath = Paths.get(this.originalPath.toString(), mainTargetName, sourcesDir);
 
     if (fileSystem.exists(originalPath)) {
       Path relativePath = pathRelativizer.outputDirToRootRelative(originalPath);

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1633,7 +1633,7 @@ public class ProjectGenerator {
       extraSettingsBuilder
           .put("TARGET_NAME", buildTargetName)
           .put("SRCROOT", srcRoot);
-      if ((productType == ProductTypes.UI_TEST || productType == ProductTypes.UNIT_TEST) && isFocusedOnTarget) {
+      if (productType == ProductTypes.UI_TEST && isFocusedOnTarget) {
         if (bundleLoaderNode.isPresent()) {
           BuildTarget testTarget = bundleLoaderNode.get().getBuildTarget();
           extraSettingsBuilder.put("TEST_TARGET_NAME", getXcodeTargetName(testTarget));

--- a/src/com/facebook/buck/features/apple/project/ProjectGeneratorOptions.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGeneratorOptions.java
@@ -40,6 +40,12 @@ interface ProjectGeneratorOptions {
     return false;
   }
 
+  /** Create schemes for each target's contained build and test targets. */
+  @Value.Default
+  default boolean shouldGenerateTargetSchemes() {
+    return false;
+  }
+
   /** Generate read-only project files */
   @Value.Default
   default boolean shouldGenerateReadOnlyFiles() {

--- a/src/com/facebook/buck/features/apple/project/XCodeProjectCommandHelper.java
+++ b/src/com/facebook/buck/features/apple/project/XCodeProjectCommandHelper.java
@@ -143,6 +143,7 @@ public class XCodeProjectCommandHelper {
   private final String modulesToFocusOn;
   private final boolean combinedProject;
   private final boolean createProjectSchemes;
+  private final boolean createTargetSchemes;
   private final boolean dryRun;
   private final boolean readOnly;
   private final PathOutputPresenter outputPresenter;
@@ -179,6 +180,7 @@ public class XCodeProjectCommandHelper {
       String modulesToFocusOn,
       boolean combinedProject,
       boolean createProjectSchemes,
+      boolean createTargetSchemes,
       boolean dryRun,
       boolean readOnly,
       PathOutputPresenter outputPresenter,
@@ -210,6 +212,7 @@ public class XCodeProjectCommandHelper {
     this.modulesToFocusOn = modulesToFocusOn;
     this.combinedProject = combinedProject;
     this.createProjectSchemes = createProjectSchemes;
+    this.createTargetSchemes = createTargetSchemes;
     this.dryRun = dryRun;
     this.readOnly = readOnly;
     this.outputPresenter = outputPresenter;
@@ -379,6 +382,7 @@ public class XCodeProjectCommandHelper {
             .setShouldUseShortNamesForTargets(true)
             .setShouldCreateDirectoryStructure(combinedProject)
             .setShouldGenerateProjectSchemes(createProjectSchemes)
+            .setShouldGenerateTargetSchemes(createTargetSchemes)
             .build();
 
     LOG.debug("Xcode project generation: Generates workspaces for targets");

--- a/src/com/facebook/buck/features/apple/project/XCodeProjectSubCommand.java
+++ b/src/com/facebook/buck/features/apple/project/XCodeProjectSubCommand.java
@@ -39,6 +39,7 @@ public class XCodeProjectSubCommand extends ProjectSubCommand {
 
   private static final boolean DEFAULT_READ_ONLY_VALUE = false;
   private static final boolean DEFAULT_PROJECT_SCHEMES = false;
+  private static final boolean DEFAULT_TARGET_SCHEMES = false;
   private static final boolean DEFAULT_ABSOLUTE_HEADER_MAP_PATHS = false;
   private static final boolean DEFAULT_SHARED_LIBRARIES_AS_DYNAMIC_FRAMEWORKS = false;
 
@@ -51,6 +52,11 @@ public class XCodeProjectSubCommand extends ProjectSubCommand {
       name = "--project-schemes",
       usage = "Generate an xcode scheme for each sub-project with its targets and tests.")
   private boolean projectSchemes = false;
+
+  @Option(
+      name = "--target-schemes",
+      usage = "Generate an xcode scheme for each sub-target with its targets and tests.")
+  private boolean targetSchemes = false;
 
   @Option(
       name = "--focus",
@@ -139,6 +145,7 @@ public class XCodeProjectSubCommand extends ProjectSubCommand {
               modulesToFocusOn,
               combinedProject,
               getProjectSchemes(params.getBuckConfig()),
+              getTargetSchemes(params.getBuckConfig()),
               projectGeneratorParameters.isDryRun(),
               getReadOnly(params.getBuckConfig()),
               new PrintStreamPathOutputPresenter(
@@ -183,6 +190,7 @@ public class XCodeProjectSubCommand extends ProjectSubCommand {
                   projectGeneratorParameters.isWithoutDependenciesTests(),
                   modulesToFocusOn,
                   getProjectSchemes(params.getBuckConfig()),
+                  getTargetSchemes(params.getBuckConfig()),
                   projectGeneratorParameters.isDryRun(),
                   getReadOnly(params.getBuckConfig()),
                   new PrintStreamPathOutputPresenter(
@@ -212,6 +220,12 @@ public class XCodeProjectSubCommand extends ProjectSubCommand {
     // command line arg takes precedence over buck config
     return projectSchemes
         || buckConfig.getBooleanValue("project", "project_schemes", DEFAULT_PROJECT_SCHEMES);
+  }
+
+  private boolean getTargetSchemes(BuckConfig buckConfig) {
+    // command line arg takes precedence over buck config
+    return targetSchemes
+        || buckConfig.getBooleanValue("project", "target_schemes", DEFAULT_TARGET_SCHEMES);
   }
 
   private boolean getReadOnly(BuckConfig buckConfig) {

--- a/src/com/facebook/buck/features/apple/projectV2/ProjectGeneratorOptions.java
+++ b/src/com/facebook/buck/features/apple/projectV2/ProjectGeneratorOptions.java
@@ -34,6 +34,12 @@ public interface ProjectGeneratorOptions {
     return false;
   }
 
+  /** Create schemes for each target's contained build and test targets. */
+  @Value.Default
+  default boolean shouldGenerateTargetSchemes() {
+    return false;
+  }
+
   /** Generate read-only project files */
   @Value.Default
   default boolean shouldGenerateReadOnlyFiles() {

--- a/src/com/facebook/buck/features/apple/projectV2/XCodeProjectCommandHelper.java
+++ b/src/com/facebook/buck/features/apple/projectV2/XCodeProjectCommandHelper.java
@@ -142,6 +142,7 @@ public class XCodeProjectCommandHelper {
   private final boolean withoutTests;
   private final boolean withoutDependenciesTests;
   private final boolean createProjectSchemes;
+  private final boolean createTargetSchemes;
   private final boolean dryRun;
   private final boolean readOnly;
   private final PathOutputPresenter outputPresenter;
@@ -178,6 +179,7 @@ public class XCodeProjectCommandHelper {
       boolean withoutDependenciesTests,
       String focus,
       boolean createProjectSchemes,
+      boolean createTargetSchemes,
       boolean dryRun,
       boolean readOnly,
       PathOutputPresenter outputPresenter,
@@ -206,6 +208,7 @@ public class XCodeProjectCommandHelper {
     this.withoutTests = withoutTests;
     this.withoutDependenciesTests = withoutDependenciesTests;
     this.createProjectSchemes = createProjectSchemes;
+    this.createTargetSchemes = createTargetSchemes;
     this.dryRun = dryRun;
     this.readOnly = readOnly;
     this.outputPresenter = outputPresenter;
@@ -406,6 +409,7 @@ public class XCodeProjectCommandHelper {
                 appleConfig.shouldGenerateMissingUmbrellaHeaders())
             .setShouldUseShortNamesForTargets(true)
             .setShouldGenerateProjectSchemes(createProjectSchemes)
+            .setShouldGenerateTargetSchemes(createTargetSchemes)
             .build();
 
     LOG.debug("Xcode project generation: Generates workspaces for targets");


### PR DESCRIPTION
# Note:
- The target of a subproject can display schemes (target scheme and test scheme) on the workspace scheme.
- Test targets must have a name suffix of `Tests`.
- The `Tests` group refers to the `Tests` directory in the local.